### PR TITLE
Fix WaitAndRetry with calculated timeout

### DIFF
--- a/NewPolicyCommand.cs
+++ b/NewPolicyCommand.cs
@@ -65,7 +65,7 @@ namespace pspolly
                                            return (TimeSpan)psObject[0].BaseObject;
                                        });
                 }
-                if (RetryWait != null)
+                else if (RetryWait != null)
                 {
                     policy = policyBuilder.WaitAndRetry(RetryWait);
                 }


### PR DESCRIPTION
The second `if` in this block was always overwriting the `WaitAndRetry` policy.